### PR TITLE
feat: Adopt shared reusable claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,8 @@
 name: Claude Code
 
+# Thin caller for the shared reusable workflow — the @claude mention filter,
+# permissions, git-policies fetch, and action invocation live in J-MaFf/.github.
+
 on:
   issue_comment:
     types: [created]
@@ -12,50 +15,11 @@ on:
 
 jobs:
   claude:
-    # Only run when "@claude" is mentioned in the relevant comment, review, issue body, or issue title.
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    # ubuntu-latest: the action installs the Claude CLI here reliably (it cannot on
-    # windows-latest). Windows-specific test execution lives in windows-tests.yml.
-    runs-on: ubuntu-latest
+    uses: J-MaFf/.github/.github/workflows/claude.yml@main
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Load git-policies into CLAUDE.md
-        run: |
-          url="https://raw.githubusercontent.com/J-MaFf/J-MaFf.github.io/main/claude/git-policies.md"
-          if curl -fsSL "$url" -o /tmp/git-policies.md; then
-            {
-              printf '\n<!-- BEGIN git-policies (fetched at runtime from %s) -->\n' "$url"
-              cat /tmp/git-policies.md
-              printf '\n<!-- END git-policies -->\n'
-            } >> CLAUDE.md
-            echo "Loaded git-policies into CLAUDE.md ($(wc -l < /tmp/git-policies.md) lines)."
-          else
-            echo "::warning::Could not fetch git-policies from $url; proceeding without it."
-          fi
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          # Authenticate with a Claude Pro/Max subscription OAuth token (generated via `claude setup-token`)
-          # instead of a pay-as-you-go ANTHROPIC_API_KEY. Stored as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Optional configuration (uncomment to customize):
-          # trigger_phrase: "@claude"
-          # claude_args: |
-          #   --model claude-sonnet-4-6
-          #   --max-turns 10
+      actions: read
+    secrets: inherit


### PR DESCRIPTION
Fixes #46

Replaces the ~60-line copied Claude Code job with a thin caller of `J-MaFf/.github/.github/workflows/claude.yml@main` (explicit `permissions` + `secrets: inherit`). Triggers are unchanged; the `@claude` mention filter now lives in the shared workflow, which standardizes on `checkout@v7`.

Part of the fleet-wide consolidation validated in J-MaFf/homelab#21.