### PR TITLE
fix: Guard _request() error handler against unbound response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `claude.yml` now calls the shared reusable Claude workflow in [J-MaFf/.github](https://github.com/J-MaFf/.github) instead of carrying its own copy ([#47](https://github.com/J-MaFf/clickup_task_creator/pull/47))
 
+### Fixed
+- Fixed `UnboundLocalError` in `ClickUpAPIClient._request()` when a request failed before a response existed (connection errors, SSL failures, too many redirects); these now raise `APIError` as intended ([#60](https://github.com/J-MaFf/clickup_task_creator/pull/60))
+- Fixed retry logic consulting the previous attempt's status code when a later attempt failed at the connection level ([#60](https://github.com/J-MaFf/clickup_task_creator/pull/60))
+
 ## [0.1.0] - 2025-11-18
 
 ### Added

--- a/api_client.py
+++ b/api_client.py
@@ -84,8 +84,12 @@ class ClickUpAPIClient:
             RateLimitError: On rate limit exceeded
         """
         url = urljoin(self.base_url, endpoint)
-        
+
         for attempt in range(retries):
+            # Reset per attempt so a failure before the request completes never
+            # inspects the previous attempt's response
+            response = None
+
             try:
                 logger.debug(f"{method} {url} (attempt {attempt + 1}/{retries})")
                 
@@ -121,7 +125,8 @@ class ClickUpAPIClient:
             
             except requests.exceptions.RequestException as e:
                 logger.error(f"Request failed: {e}")
-                if attempt < retries - 1 and response.status_code >= 500:
+                is_server_error = response is not None and response.status_code >= 500
+                if attempt < retries - 1 and is_server_error:
                     time.sleep(EXPONENTIAL_BACKOFF_BASE ** attempt)
                     continue
                 raise APIError(f"API request failed: {e}")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,6 +1,7 @@
 """Tests for api_client module."""
 
 import pytest
+import requests
 from unittest.mock import Mock, patch
 
 from api_client import ClickUpAPIClient, APIError, RateLimitError
@@ -39,5 +40,41 @@ def test_post_request(mock_request):
     
     client = ClickUpAPIClient(api_key="test_key")
     result = client.post("/test", {"name": "test"})
-    
+
     assert result == {"id": "123"}
+
+
+@patch("api_client.time.sleep")
+@patch("api_client.requests.Session.request")
+def test_connection_error_raises_api_error(mock_request, mock_sleep):
+    """Test that a failure before any response exists raises APIError."""
+    mock_request.side_effect = requests.exceptions.ConnectionError("no route to host")
+
+    client = ClickUpAPIClient(api_key="test_key")
+
+    with pytest.raises(APIError, match="API request failed"):
+        client.get("/team")
+
+
+@patch("api_client.time.sleep")
+@patch("api_client.requests.Session.request")
+def test_connection_error_after_server_error_does_not_reuse_response(mock_request, mock_sleep):
+    """Test that a connection error does not retry based on a prior attempt's status."""
+    server_error = Mock()
+    server_error.status_code = 503
+    server_error.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "503 Server Error"
+    )
+
+    mock_request.side_effect = [
+        server_error,
+        requests.exceptions.ConnectionError("connection reset"),
+    ]
+
+    client = ClickUpAPIClient(api_key="test_key")
+
+    with pytest.raises(APIError, match="API request failed"):
+        client.get("/team")
+
+    # The 503 is retried; the connection error that follows is not
+    assert mock_request.call_count == 2


### PR DESCRIPTION
Fixes #59

## Problem

`ClickUpAPIClient._request()` read `response.status_code` inside its `RequestException` handler to decide whether to retry. `response` is only assigned inside the `try` block, so any failure raised by the request itself left it unbound and the handler raised `UnboundLocalError` instead of `APIError`:

```python
except requests.exceptions.RequestException as e:
    logger.error(f"Request failed: {e}")
    if attempt < retries - 1 and response.status_code >= 500:   # <- unbound
```

Affected: `ConnectionError` (DNS failure, connection refused, network down), `SSLError`, `TooManyRedirects`. It surfaced to the user as "Unexpected error" plus an unrelated traceback, via `main()`'s generic `except Exception` branch.

The `HTTPError` path was never affected — `raise_for_status()` runs after `response` is bound — so the 5xx retry logic itself was fine.

## Secondary bug

`response` also persisted across loop iterations. A 503 on attempt 1 followed by a `ConnectionError` on attempt 2 made the retry decision off the stale 503, producing a request that should never have been sent.

## Fix

Reset `response = None` at the top of each attempt and guard the 5xx check with an explicit `None` test. One change addresses both.

## Testing

Two regression tests added to `tests/test_api_client.py`:

- `test_connection_error_raises_api_error` — a `ConnectionError` on the first attempt raises `APIError`
- `test_connection_error_after_server_error_does_not_reuse_response` — a 503 then a `ConnectionError` stops at exactly 2 requests

Both fail on the unfixed code (`UnboundLocalError` and a `StopIteration` from the spurious third request respectively) and pass with the fix.

```
31 passed in 0.28s
```

Suite run under Python 3.14 with `pytest` + `requests` + `rich`; no coverage config exists in the repo yet (tracked in #57).